### PR TITLE
Fix CI gate for path-filtered workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,10 +7,6 @@ on:
       - build/*
       - VERSION
   pull_request:
-    paths:
-      - .github/workflows/build.yaml
-      - build/*
-      - VERSION
   workflow_dispatch:
 
 env:
@@ -20,10 +16,27 @@ env:
   PLATFORMS: linux/amd64,linux/arm64/v8,linux/riscv64
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            build:
+              - '.github/workflows/build.yaml'
+              - 'build/**'
+              - 'VERSION'
+
   test:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.ref != 'refs/heads/master'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.build == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -225,3 +238,10 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ env.version }}
           docker buildx imagetools inspect ${{ env.GHCR_REPO }}:${{ env.version }}
+
+  ci-required:
+    if: ${{ failure() || cancelled() }}
+    needs: [changes, test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1

--- a/.github/workflows/update-check.yaml
+++ b/.github/workflows/update-check.yaml
@@ -6,16 +6,32 @@ on:
       - .github/workflows/update-check.yaml
       - update-check.py
   pull_request:
-    paths:
-      - .github/workflows/update-check.yaml
-      - update-check.py
   schedule:
   - cron: '0 0 * * *'  # runs every day at midnight UTC
   workflow_dispatch:
 
 jobs:
-  check:
+  changes:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      update-check: ${{ steps.filter.outputs.update-check }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            update-check:
+              - '.github/workflows/update-check.yaml'
+              - 'update-check.py'
+
+  check:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.update-check == 'true'
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -28,3 +44,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: python3 update-check.py ${{ github.event_name == 'pull_request' }}
+
+  ci-required:
+    if: ${{ failure() || cancelled() }}
+    needs: [changes, check]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1


### PR DESCRIPTION
Remove paths: filters from pull_request triggers and add dorny/paths-filter change detection jobs so workflows always trigger on PRs but conditionally skip the heavy jobs. Add ci-required gate jobs that only fail on failure/cancellation — skipped jobs report as success, unblocking PRs that don't touch build-relevant files (e.g. PR #16).