### PR TITLE
Fix gpg-agent IPC error on runtime startup with KEYRING_PASSPHRASE

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -10,11 +10,22 @@ fi
 
 # Preset passphrase into gpg-agent for pass/bridge to decrypt credentials
 setup_gpg_passphrase() {
-    # Ensure gpg-agent.conf allows preset passphrases
-    gpg --list-keys >&/dev/null
-    if ! grep -q "allow-preset-passphrase" "$HOME"/.gnupg/gpg-agent.conf 2>/dev/null; then
-        echo "allow-preset-passphrase" >> "$HOME"/.gnupg/gpg-agent.conf
-        gpg-connect-agent reloadagent /bye
+    local conf="$HOME/.gnupg/gpg-agent.conf"
+    mkdir -p "$HOME/.gnupg"
+    chmod 700 "$HOME/.gnupg"
+
+    local needs_reload=0
+    if ! grep -q "allow-preset-passphrase" "$conf" 2>/dev/null; then
+        echo "allow-preset-passphrase" >> "$conf"
+        needs_reload=1
+    fi
+
+    # gpg-preset-passphrase does not auto-start gpg-agent, and listing public
+    # keys alone does not reliably spawn it. Launch explicitly.
+    gpgconf --launch gpg-agent
+
+    if [ "$needs_reload" = "1" ]; then
+        gpg-connect-agent reloadagent /bye >/dev/null
     fi
 
     local keygrip


### PR DESCRIPTION
## Summary

Fixes #54.

When `KEYRING_PASSPHRASE` is set, the runtime (non-init) startup path was hitting `gpg: can't connect to '/root/.gnupg/S.gpg-agent': IPC connect call failed`. The `init` path was unaffected because key generation kept gpg-agent warm, masking the bug during testing.

Root cause: `gpg-preset-passphrase` does not auto-start gpg-agent, and the `gpg --list-keys` call that was meant to spawn it does not reliably do so on pubring-only reads. Combined with the stale-socket cleanup at container startup, the runtime path often tried to preset the passphrase against a missing agent.

## Changes

- `build/entrypoint.sh`: launch gpg-agent explicitly with `gpgconf --launch gpg-agent` before calling `gpg-preset-passphrase`
- Only reload the agent when `allow-preset-passphrase` was just appended (avoids an unnecessary reload on every start)
- Ensure `~/.gnupg` exists with 0700 permissions as a defensive measure

## Test plan

Verified against a local build of this branch:

- [x] `init` with `KEYRING_PASSPHRASE` — key generated (RSA 4096, passphrase-protected), no errors
- [x] Normal startup with same volume + `KEYRING_PASSPHRASE` — container reports healthy, gpg-agent running, keygrip has cached passphrase (`KEYINFO ... 1 P`), no IPC errors in logs
- [x] `docker restart` on the running container — stale-socket cleanup + re-launch cycle works, passphrase re-cached cleanly
- [x] Backward compat: behavior without `KEYRING_PASSPHRASE` unchanged (function not called)