### PR TITLE
Discard staged bridge updates and disable auto-update at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An unofficial Docker container for the [Proton Mail Bridge](https://proton.me/ma
 This fork includes fixes and improvements that are not yet merged upstream:
 
 - **Fixes v3.22.0+** — adds missing `libfido2` and `libcbor` runtime dependencies that caused containers to fail to start
-- **Auto-updater disabled** — the bridge's built-in self-updater is blocked; version management is handled by the container image itself (no more broken arm64 containers due to amd64 binary replacement)
+- **Auto-updater disabled** — the bridge's built-in self-updater is turned off and any update it previously downloaded is discarded at startup; version management is handled by the container image itself (no more broken arm64 containers due to the launcher running an amd64 download)
 - **Long-uptime stability fix** — replaced the fragile stdin pipe with `sleep infinity`, preventing the bridge from detaching after several days of uptime
 - **Stale GPG socket cleanup** — removes leftover `S.gpg-agent` sockets on startup, preventing auth failures after container restarts
 - **Health check** — Docker reports container health based on the bridge process status
@@ -41,7 +41,7 @@ or `docker pull dancwilliams/protonmail-bridge` + container restart. No re-initi
 Tags no longer carry a `-build` suffix. If you were pinning to a tag like `v3.21.2-build`, update your compose file or run command to use `v3.21.2` instead. Users tracking `latest` are unaffected.
 
 **Auto-updater disabled**
-The bridge's built-in self-updater is now permanently blocked (bridge binaries are made read-only at image build time). This prevents the updater from replacing container binaries at runtime, which previously caused broken arm64 containers when it downloaded an amd64 binary. Version updates now come exclusively through new container image releases, which this repository handles automatically via a daily version check.
+The bridge's built-in self-updater downloads Proton's amd64 Linux build into the data volume, and the bridge launcher runs that copy on the next start instead of the image's binaries. On arm64 that meant an `exec format error` crash loop after every upstream release; on amd64 it silently ran a version the image never shipped. The entrypoint now deletes any staged download before launch and, on first start, turns auto-update off in the bridge's settings. Version updates come exclusively through new container image releases, which this repository handles automatically via a daily version check. To re-enable auto-update for some reason, run `init` and use `updates autoupdates enable`; the staged download will still be discarded on each restart.
 
 ## Architectures
 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# The launcher execs any newer bridge it finds here (downloaded by the
+# built-in updater, amd64 only) instead of the image's binaries. Drop it so
+# the image version always runs, on every architecture.
+rm -rf "$HOME/.local/share/protonmail/bridge-v3/updates"
+
 # Workaround for stale gpg-agent socket causing auth failures on restart
 # Cleans up leftover sockets in the GPG home directory
 if [ -d /root/.gnupg ]; then
@@ -91,6 +96,14 @@ else
 
     # Start bridge reading from faketty; wait so container exits with bridge's exit code
     /protonmail/proton-bridge --cli $@ < faketty &
+
+    # Persist AutoUpdate=false in the vault so the updater stops downloading.
+    # Done once; a repeat would leave a stray "yes" in the bridge shell.
+    if [ ! -f "$HOME/.autoupdate-disabled" ]; then
+        printf 'updates autoupdates disable\nyes\n' > faketty
+        touch "$HOME/.autoupdate-disabled"
+    fi
+
     wait $!
     exit $?
 


### PR DESCRIPTION
Fixes #97.

The bridge's built-in updater downloads Proton's amd64 Linux build into the data volume (`~/.local/share/protonmail/bridge-v3/updates/<version>/`), and the launcher execs any newer signed version it finds there instead of the image binaries. The read-only chmod on the image binaries never blocked this path, so the README's "auto-updater disabled" claim was wrong. On arm64 the result is an `exec format error` crash loop after every upstream release. On amd64 the container silently runs a version the image never shipped.

**Changes**
- `entrypoint.sh`: remove the updates directory before launching (both init and run paths), so the image's bridge always runs.
- `entrypoint.sh`: on first start, send `updates autoupdates disable` plus confirmation through the fake terminal so `AutoUpdate=false` persists in existing vaults. A marker file in the volume prevents repeating it.
- README: describe what actually happens and how to re-enable if ever wanted.

**Testing** (local, `v3.25.0` image with a real signed 3.26.0 update staged in the volume)
- amd64, old entrypoint (control): launcher ran `updates/3.26.0/bridge` instead of `/protonmail/bridge`. Bug reproduced.
- arm64 under QEMU, old entrypoint (control): launcher died trying to exec the amd64 download. Bug reproduced.
- amd64 and arm64, new entrypoint: `/protonmail/bridge` runs, staged update gone, vault reads back `AutoUpdate: false`, second start prints nothing extra, init path clean.
- amd64 with `KEYRING_PASSPHRASE`: same results.

Supersedes #33, which only changed the default for newly created vaults.
