### PR TITLE
Stop the container promptly instead of waiting out the grace period

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -70,8 +70,8 @@ if [[ $1 == init ]]; then
     # || true to make sure this would not fail in case there is no running instance.
     pkill -f proton-bridge || true
 
-    # Login
-    /protonmail/proton-bridge --cli $@
+    # Login. exec so the CLI becomes PID 1 and receives signals directly.
+    exec /protonmail/proton-bridge --cli "$@"
 
 else
 
@@ -86,25 +86,38 @@ else
     socat TCP-LISTEN:25,fork TCP:127.0.0.1:1025 &
     socat TCP-LISTEN:143,fork TCP:127.0.0.1:1143 &
 
-    # Start protonmail
-    # Fake a terminal, so it does not quit because of EOF...
-    rm -f faketty
-    mkfifo faketty
-
-    # Keep faketty open indefinitely (more stable than cat pipe over long uptimes)
-    sleep infinity > faketty &
-
-    # Start bridge reading from faketty; wait so container exits with bridge's exit code
-    /protonmail/proton-bridge --cli $@ < faketty &
-
     # Persist AutoUpdate=false in the vault so the updater stops downloading.
-    # Done once; a repeat would leave a stray "yes" in the bridge shell.
-    if [ ! -f "$HOME/.autoupdate-disabled" ]; then
-        printf 'updates autoupdates disable\nyes\n' > faketty
-        touch "$HOME/.autoupdate-disabled"
+    #
+    # This used to be typed into the faketty FIFO of the long-running --cli
+    # session. That session is gone (see below), so it is done here instead, in
+    # a short-lived --cli run fed on stdin: the CLI quits on EOF -- the very
+    # behaviour faketty existed to prevent -- so the pipe closing ends it.
+    #
+    # Guarded by a marker so it costs one extra bridge startup once in the life
+    # of the volume, not one per boot. `if` also shields the pipeline from
+    # `set -e`: failing to persist a preference must not stop the container from
+    # starting, and an unwritten marker simply retries on the next boot.
+    #
+    # The password store is a precondition, not a nicety. Started on a volume
+    # that has never seen `init`, the bridge finds no keychain, opens no vault
+    # and has nowhere to write the setting -- yet the marker would be dropped
+    # all the same, so the later `init` would never get its AutoUpdate=false.
+    if [ ! -f "$HOME/.autoupdate-disabled" ] && [ -d "$HOME/.password-store" ]; then
+        if printf 'updates autoupdates disable\nyes\n' | /protonmail/proton-bridge --cli; then
+            touch "$HOME/.autoupdate-disabled"
+        fi
     fi
 
-    wait $!
-    exit $?
+    # Start protonmail.
+    #
+    # --noninteractive is the upstream-supported way to run the bridge without a
+    # frontend, so no terminal has to be faked at all: the faketty FIFO and the
+    # process that had to hold it open are both gone.
+    #
+    # exec matters as much as the flag. Without it bash stays PID 1, and the
+    # kernel does not deliver default-action signals to PID 1, so SIGTERM was
+    # silently discarded and every `docker stop` ended in SIGKILL after the
+    # 10s grace period (exit 137) with the vault never closed cleanly.
+    exec /protonmail/proton-bridge --noninteractive "$@"
 
 fi


### PR DESCRIPTION
## Problem

`bash` stays PID 1 and waits on a backgrounded bridge. The kernel does not deliver
default-action signals to PID 1, so with no trap installed SIGTERM is discarded
outright: every `docker stop`, `compose pull && up -d` or host reboot sits through the
entire grace period and ends in SIGKILL.

## Fix

Run the bridge under `exec`, so the launcher is PID 1 and terminates on SIGTERM. That
requires no frontend on stdin, which upstream already supports through
`--noninteractive` (`internal/app/frontend.go`), so the faketty FIFO and the process
holding it open are no longer needed and are removed.

The `init` path gains the same `exec` treatment, and `"$@"` is now quoted in both so
arguments containing spaces survive.

## Measured

v3.26.0, same image otherwise, identical ports served (25, 143, 1025 and 1143 all
accepting), `stop -t 30`:

| | PID 1 | `stop` | exit code |
|---|---|---|---|
| before | `bash /protonmail/entrypoint.sh` | 30.21s | 137 (SIGKILL) |
| after | `/protonmail/proton-bridge --noninteractive` | **0.16s** | 143 (SIGTERM) |

## What this does not do

It does not make the shutdown graceful, and I'd rather say so than let the title imply
otherwise. proton-bridge 3.26.0 installs no signal handler anywhere — neither the
launcher nor the bridge registers `signal.Notify` — so the process still terminates
without running any cleanup, and the bridge child is reaped by the PID namespace
teardown right after. I confirmed this by sending SIGTERM to the bridge child directly:
the launcher logs `Failed to launch  error="signal: terminated"` and restarts it, with
no shutdown path of its own.

So the vault and the Gluon database are left exactly as abruptly as before. What changes
is that the container stops in milliseconds instead of hanging for the whole grace
period on every restart, and reports 143 rather than 137. A genuinely graceful shutdown
needs signal handling upstream, which is out of scope for this repo.

## Interaction with #98

Removing the FIFO takes away the channel 386559e used to persist `AutoUpdate=false` in
the vault, so that step moves to a short-lived `--cli` run fed on stdin: the CLI quits
on EOF — precisely the behaviour faketty existed to prevent — so closing the pipe ends
the session. It stays guarded by the same marker file, costing one extra bridge startup
once in the life of the volume rather than one per boot, and it can no longer abort the
container start if it fails: an unwritten marker just retries on the next boot. It is
also gated on the password store existing: on a volume that has never seen `init` there
is no keychain, so no vault opens and the setting has nowhere to go — yet the marker
would have been dropped all the same and the later `init` would never have got its
`AutoUpdate=false`. The `rm -rf .../updates` half of 386559e is untouched and still runs
on every start.

## Verified locally

Built from this branch (v3.26.0, `debian:bookworm-slim`) and exercised in a container,
including against a real account after `init` and initial sync:

| check | result |
|---|---|
| PID 1 | `/protonmail/proton-bridge --noninteractive` — no `faketty`, no `sleep infinity` |
| `stop -t 30` | 0.16 s, exit 143, against 30.21 s / exit 137 on `master` |
| `AutoUpdate` in vault | `false`, read back with the shipped `vault-editor`, on a real logged-in vault |
| `up` before `init` | marker no longer dropped early; after `init` + reboot, `AutoUpdate: false` |
