### PR TITLE
Base the healthcheck on served ports, not process presence

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,9 +23,9 @@ LABEL maintainer="Dan Williams <dancwilliams@github>"
 EXPOSE 25/tcp
 EXPOSE 143/tcp
 
-# Monitor proton-bridge process health
+# Monitor that the container actually serves mail, not merely that a process exists
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=60s \
-  CMD bash -c "pgrep -f proton-bridge || exit 1"
+  CMD bash /protonmail/healthcheck.sh
 
 # Install runtime dependencies
 RUN apt-get -o Acquire::http::Timeout=30 update \
@@ -33,7 +33,7 @@ RUN apt-get -o Acquire::http::Timeout=30 update \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy bash scripts
-COPY gpgparams entrypoint.sh /protonmail/
+COPY gpgparams entrypoint.sh healthcheck.sh /protonmail/
 
 # Copy protonmail
 COPY --from=build /build/bridge /protonmail/

--- a/build/healthcheck.sh
+++ b/build/healthcheck.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Report the container healthy only if it can actually serve mail.
+#
+# Checking that a bridge process exists is not enough: socat provides the
+# published ports 25/143 and is neither supervised nor restarted, so it can die
+# while the bridge keeps running. The container then accepts no connection at
+# all but still reports healthy, and nothing restarts it.
+#
+# Both hops are checked: the socat listeners on 25/143, and the bridge itself on
+# 1025/1143 behind them. bash's /dev/tcp is used so the image needs no
+# additional package.
+
+set -u
+
+# `docker run ... init` drops the user into the bridge CLI to log in, and that
+# path deliberately starts no socat: 25 and 143 are closed by design there, for
+# as long as the login and the initial sync take. HEALTHCHECK is an image-level
+# property and applies to that container too, so without this the whole
+# onboarding shows up as unhealthy.
+#
+# PID 1 is matched on `init` rather than on `--cli`, because it reads
+# "bash /protonmail/entrypoint.sh init" for as long as the GPG key is being
+# generated and only becomes "/protonmail/proton-bridge --cli init" once the
+# entrypoint execs. `init` is the one token present through both phases, and it
+# never appears in the serving path ("--noninteractive").
+if grep -qE '(^| )(init|--cli)( |$)' <(tr '\0' ' ' < /proc/1/cmdline); then
+    echo "interactive CLI session, nothing to serve yet"
+    exit 0
+fi
+
+# Probe one port and walk out through the front door: greet, say goodbye, and
+# read the reply until the peer hangs up. Anything less makes the bridge log an
+# error on every single probe -- dropping the socket outright gives
+# "connection reset by peer", and closing before reading the farewell reply
+# gives "write: broken pipe". Either would bury real errors in the logs.
+#
+# Reads are line-based and timeout-bounded: a size-based read would block until
+# the peer closes, and both protocols speak in CRLF lines.
+#
+# The connect is wrapped in a group because a failing `exec` redirection is
+# reported by the shell itself, which a redirection on `exec` alone does not
+# silence -- the refusal would leak into the health log next to our own message.
+probe() {
+    local port=$1 farewell=$2
+
+    { exec 3<>"/dev/tcp/127.0.0.1/${port}"; } 2>/dev/null || return 1
+
+    IFS= read -r -t 3 -u 3 _ 2>/dev/null                    # greeting
+    printf '%s\r\n' "$farewell" >&3 2>/dev/null             # QUIT / LOGOUT
+    while IFS= read -r -t 2 -u 3 _ 2>/dev/null; do :; done  # reply, until EOF
+
+    exec 3<&- 3>&-
+    return 0
+}
+
+probe 25   "QUIT"      || { echo "SMTP port 25 is not accepting connections";        exit 1; }
+probe 143  "a LOGOUT"  || { echo "IMAP port 143 is not accepting connections";       exit 1; }
+probe 1025 "QUIT"      || { echo "bridge SMTP (1025) is not accepting connections";  exit 1; }
+probe 1143 "a LOGOUT"  || { echo "bridge IMAP (1143) is not accepting connections";  exit 1; }


### PR DESCRIPTION
## Problem

The healthcheck runs `pgrep -f proton-bridge`, which only proves a process exists. The
published ports 25 and 143 are served by two `socat` processes that are neither
supervised nor restarted, so they can die while the bridge keeps running. The container
then accepts no connection at all but still reports healthy, so no orchestrator
restarts it.

Reproduced on a healthy container by killing both `socat` processes:

| | health | 25 | 143 | 1025 | 1143 |
|---|---|---|---|---|---|
| before | healthy | OPEN | OPEN | OPEN | OPEN |
| after kill | **healthy** | closed | closed | OPEN | OPEN |

## Fix

Check instead that all four ports accept a connection, which covers both the `socat`
listeners and the bridge behind them. The same scenario now reports unhealthy with the
reason on stdout, and killing the bridge while `socat` stays up — the case `pgrep` was
blindest to — is caught as well.

The probe completes the protocol handshake rather than dropping the socket: it reads
the greeting, sends `QUIT`/`LOGOUT` and drains the reply until the peer hangs up.
Dropping the socket instead made the bridge log `connection reset by peer` on every
probe, and closing before reading the farewell reply made it log `write: broken pipe` —
either would have buried real errors under one entry every 30 seconds. Measured over
5 cycles on v3.26.0: no SMTP or IMAP error logged, one probe taking 4 ms.

`docker run ... init` is exempted: that path deliberately starts no `socat`, so 25 and
143 are closed by design for as long as the login and the initial sync take. Since
HEALTHCHECK is an image-level property it applies to that container too, and without
the exemption the whole onboarding shows up as unhealthy. PID 1 is matched on `init`
rather than `--cli`, because it reads `bash /protonmail/entrypoint.sh init` while the
GPG key is generated and only becomes `/protonmail/proton-bridge --cli init` once the
entrypoint execs; `init` is the one token present through both phases and never appears
in the serving path.

All reads are line-based and timeout-bounded, so a wedged peer cannot hang the check;
bash's `/dev/tcp` is used so the image needs no additional package.

## Verified locally

Built from this branch (v3.26.0, `debian:bookworm-slim`) and exercised in a container:

| check | result |
|---|---|
| nominal | healthy, four ports served, **0.16 s** per pass |
| 20 consecutive passes | **0** `connection reset by peer` / `broken pipe` logged (a socket dropped without QUIT produces exactly 1, so the handshake is doing its job) |
| 3 automatic passes at `--interval=30s` | 0 errors logged, stays healthy |
| both `socat` killed, bridge alive | 25/143 closed, 1025/1143 open → **unhealthy** (before: `healthy`, the false positive this fixes) |
| `init` container | `interactive CLI session, nothing to serve yet` → healthy |

Only `build/healthcheck.sh` is touched; independent of the SIGTERM PR.
